### PR TITLE
Added alias tax meta field.

### DIFF
--- a/includes/ucf-colleges-taxonomy.php
+++ b/includes/ucf-colleges-taxonomy.php
@@ -37,7 +37,7 @@ if ( ! class_exists( 'UCF_College_Taxonomy' ) ) {
 ?>
 			<tr class="form-field term-group-wrap">
 				<th scope="row"><label for="colleges_alias"><?php _e( 'College Alias', 'ucf_colleges' ); ?></label></th>
-				<td><input type="text" id="colleges_alias" name="colleges_alias" value="<?php echo $alias; ?>">
+				<td><input type="text" id="colleges_alias" name="colleges_alias" value="<?php echo $alias; ?>"></td>
 			</tr>
 <?php
 		}

--- a/includes/ucf-colleges-taxonomy.php
+++ b/includes/ucf-colleges-taxonomy.php
@@ -9,6 +9,76 @@ if ( ! class_exists( 'UCF_College_Taxonomy' ) ) {
 	class UCF_College_Taxonomy {
 		public static function register_colleges() {
 			register_taxonomy( 'colleges', array(), self::args() );
+			self::register_meta_fields();
+		}
+
+		public static function register_meta_fields() {
+			add_action( 'colleges_add_form_fields', array( 'UCF_College_Taxonomy', 'add_alias_field' ), 10, 1 );
+			add_action( 'colleges_edit_form_fields', array( 'UCF_College_Taxonomy', 'edit_alias_field' ), 10, 2 );
+			add_action( 'created_colleges', array( 'UCF_College_Taxonomy', 'save_colleges_meta' ), 10, 2 );
+			add_action( 'edited_colleges', array( 'UCF_College_Taxonomy', 'edited_colleges_meta' ), 10, 2 );
+
+			add_filter( 'manage_edit-colleges_columns', array( 'UCF_College_Taxonomy', 'add_alias_column' ) );
+			add_filter( 'manage_colleges_custom_column', array( 'UCF_College_Taxonomy', 'add_colleges_alias_column' ), 10, 3 );
+			add_filter( 'manage_edit-colleges_sortable_columns', array( 'UCF_College_Taxonomy', 'add_alias_column_sortable' ) );
+		}
+
+		public static function add_alias_field( $taxonomy ) {
+?>
+			<div class="form-field term-group">
+				<label for="colleges_alias"><?php _e( 'College Alias', 'ucf_colleges' ); ?></label>
+				<input type="text" id="colleges_alias" name="colleges_alias">
+			</div>
+<?php
+		}
+
+		public static function edit_alias_field( $term, $taxonomy ) {
+			$alias = get_term_meta( $term->term_id, 'colleges_alias', true );
+?>
+			<tr class="form-field term-group-wrap">
+				<th scope="row"><label for="colleges_alias"><?php _e( 'College Alias', 'ucf_colleges' ); ?></label></th>
+				<td><input type="text" id="colleges_alias" name="colleges_alias" value="<?php echo $alias; ?>">
+			</tr>
+<?php
+		}
+
+		public static function save_colleges_meta( $term_id, $tt_id ) {
+			if ( isset( $_POST['colleges_alias'] ) && '' !== $_POST['colleges_alias'] ) {
+				$alias = $_POST['colleges_alias'];
+				add_term_meta( $term_id, 'colleges_alias', $alias, true );
+			}
+		}
+
+		public static function edited_colleges_meta( $term_id, $tt_id ) {
+			if ( isset( $_POST['colleges_alias'] ) && '' !== $_POST['colleges_alias'] ) {
+				$alias = $_POST['colleges_alias'];
+				update_term_meta( $term_id, 'colleges_alias', $alias );
+			}
+		}
+
+		public static function add_alias_column( $columns ) {
+			$columns['colleges_alias'] = __( 'Alias', 'ucf_colleges' );
+			return $columns;
+		}
+
+		public static function add_colleges_alias_column( $content, $column_name, $term_id ) {
+			if ( $column_name !== 'colleges_alias' ) {
+				return $content;
+			}
+
+			$term_id = absint( $term_id );
+			$alias = get_term_meta( $term_id, 'colleges_alias', true );
+
+			if ( ! empty( $alias ) ) {
+				$content .= esc_attr( $alias );
+			}
+
+			return $content;
+		}
+
+		public static function add_alias_column_sortable( $sortable ) {
+			$sortable[ 'colleges_alias' ] = 'colleges_alias';
+			return $sortable;
 		}
 
 		public static function labels() {

--- a/ucf-colleges-tax.php
+++ b/ucf-colleges-tax.php
@@ -11,7 +11,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 add_action( 'plugins_loaded', function() {
-	define( 'UCF_COLLEGES__PLUGIN_URL', plugins_url( 'ucf-colleges-tax' ) );
+	define( 'UCF_COLLEGES__PLUGIN_URL', plugins_url( basename( dirname( __FILE__ ) ) ) );
 	define( 'UCF_COLLEGES__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
 	include_once 'includes/ucf-colleges-taxonomy.php';


### PR DESCRIPTION
Adds the 'alias' meta field to the Colleges taxonomy. We use this pretty often so the entire college name - i.e. College of Arts and Humanities - doesn't have to appear above a list of related objects. Instead the alias can be output - i.e. 'Arts and Humanities' or just 'Arts'. Also included in the diff is the removal of a specific directory name in the PLUGIN_URL constant. Instead using the `basename()` function to get the name of the current directory.